### PR TITLE
Replaced spdlog with boost log

### DIFF
--- a/HackerChatClient/CMakeLists.txt
+++ b/HackerChatClient/CMakeLists.txt
@@ -10,13 +10,25 @@ set(PUGIXML_CPP "/opt/devtools/pugixml-1.14/src/pugixml.cpp")
 set(RAPID_JSON_H "/opt/devtools/rapidjson/rapidjson.h")
 
 include_directories(/opt/devtools/boost_1.83.0/include
-                    /opt/devtools/pugixml-1.14/src)
+        /opt/devtools/pugixml-1.14/src
+        /opt/devtools
+        /opt/devtools/spdlog)
 
-add_executable(HackerChatClient
-        HackerChatClient_main.cpp
-        HackerChatClient.hpp
-        HackerChatClient.cpp
-        ${RAPID_JSON_H}
-        ${PUGIXML_CPP}
-        WebSocket/WebSocketClient.cpp
-        WebSocket/WebSocketClient.hpp)
+# Find ExampleLib
+find_package(Boost 1.83.0 COMPONENTS log)
+
+if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIRS})
+    add_executable(HackerChatClient
+            HackerChatClient_main.cpp
+            HackerChatClient.hpp
+            HackerChatClient.cpp
+            ${RAPID_JSON_H}
+            ${PUGIXML_CPP}
+            WebSocket/WebSocketClient.cpp
+            WebSocket/WebSocketClient.hpp)
+    target_link_libraries(HackerChatClient ${Boost_LIBRARIES})
+endif()
+
+
+

--- a/HackerChatClient/HackerChatClient.cpp
+++ b/HackerChatClient/HackerChatClient.cpp
@@ -1,3 +1,5 @@
+
+#include <boost/log/trivial.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/websocket.hpp>
 #include <boost/asio/strand.hpp>
@@ -9,7 +11,6 @@
 #include <string>
 #include <thread>
 #include "HackerChatClient.hpp"
-
 
 namespace beast = boost::beast;         // from <boost/beast.hpp>
 namespace http = beast::http;           // from <boost/beast/http.hpp>
@@ -24,16 +25,17 @@ HackerChatClient::HackerChatClient():
     _stop(false){
 }
 
-bool HackerChatClient::_Load(const std::string& configFilename){
+bool HackerChatClient::_Load(const std::string& configFilePath){
     bool rc = true;
 
-    //BOOST_LOG_TRIVIAL(trace) << "Loading chat client config file...\n";
-    if (std::filesystem::exists(configFilename)){
+    BOOST_LOG_TRIVIAL(trace) << "Loading chat client config file...";
+
+    if (std::filesystem::exists(configFilePath)){
         std::fstream filestream;
         std::stringstream configBuffer;
         rapidjson::Document doc;
 
-        filestream.open(configFilename);
+        filestream.open(configFilePath);
 
         if (filestream.is_open()){
             configBuffer << filestream.rdbuf();
@@ -42,16 +44,16 @@ bool HackerChatClient::_Load(const std::string& configFilename){
             _port = doc["_port"].GetString();
             _deviceId = doc["_deviceId"].GetString();
 
-            //spdlog::warn("Successfully loading chat client configuration.");
+            BOOST_LOG_TRIVIAL(trace) << "Successfully loading chat client configuration.";
         }
         else{
             rc = false;
-            //BOOST_LOG_TRIVIAL(error) << "Failed to open HackerChatClient config file.";
+            BOOST_LOG_TRIVIAL(error) << "Failed to open HackerChatClient config file.";
         }
     }
     else{
         rc = false;
-        //BOOST_LOG_TRIVIAL(error) << "HackerChatClient config file does not exists.";
+        BOOST_LOG_TRIVIAL(error) << "HackerChatClient config file does not exists.";
     }
 
     return rc;
@@ -59,11 +61,11 @@ bool HackerChatClient::_Load(const std::string& configFilename){
 
 int HackerChatClient::_Start() {
     try {
-        // Set up logger
-        //boost::log::add_console_log(std::clog, boost::log::keywords::format = "%TimeStamp% [%Severity%]: %Message%");
+        //NOTE: Must configure IDE to store cmake build artifacts in build directory. This is temporary until
+        //We configure the CMakeList.txt to do this automatically
 
-        std::filesystem::path configPath = std::filesystem::current_path();
-        std::string configPathString = configPath.string();
+        std::filesystem::path parentPath = std::filesystem::current_path().parent_path();
+        std::string configPathString = parentPath.string();
         configPathString.append("/configs/HCClientConfig.json");
 
         if (_Load(configPathString)) {

--- a/HackerChatClient/HackerChatClient.hpp
+++ b/HackerChatClient/HackerChatClient.hpp
@@ -1,5 +1,5 @@
 #include <boost/beast/core.hpp>
-#include <boost/beast/websocket.hpp>
+//#include <boost/beast/websocket.hpp>
 #include <boost/asio/strand.hpp>
 #include <cstdlib>
 #include <functional>
@@ -10,7 +10,6 @@
 #include <string>
 
 #include "WebSocket/WebSocketClient.hpp"
-//#include "spdlog/spdlog.h"
 
 namespace beast = boost::beast;         // from <boost/beast.hpp>
 namespace http = beast::http;           // from <boost/beast/http.hpp>


### PR DESCRIPTION
I opted not to use spdlog because it required C++11 and the code base uses C++17, namely the std::filesystem feature in C++17. Therefore, I replaced spdlog with boost::log.