### PR TITLE
Modifies cmakelist.txt to allow user to set cmake build variable

### DIFF
--- a/HackerChatClient/CMakeLists.txt
+++ b/HackerChatClient/CMakeLists.txt
@@ -24,10 +24,9 @@ if (NOT RAPID_JSON_H)
     return()
 endif()
 
-include_directories(/opt/devtools/boost_1.83.0/include
-        /opt/devtools/pugixml-1.14/src
-        /opt/devtools
-        /opt/devtools/spdlog)
+include_directories(${EXTERNAL_FILES_DIR}/boost_1.83.0/include
+        ${EXTERNAL_FILES_DIR}/pugixml-1.14/src
+        ${EXTERNAL_FILES_DIR})
 
 # Find ExampleLib
 find_package(Boost 1.83.0 COMPONENTS log)

--- a/HackerChatClient/CMakeLists.txt
+++ b/HackerChatClient/CMakeLists.txt
@@ -6,8 +6,23 @@ set(CMAKE_CXX_STANDARD 17)
 set(Boost_USE_STATIC_LIBS ON)
 set(Boost_USE_MULTITHREADED OFF)
 set(Boost_USE_STATIC_RUNTIME OFF)
-set(PUGIXML_CPP "/opt/devtools/pugixml-1.14/src/pugixml.cpp")
-set(RAPID_JSON_H "/opt/devtools/rapidjson/rapidjson.h")
+
+# Check if the external files directory is provided
+if(NOT EXTERNAL_FILES_DIR)
+    message(FATAL_ERROR "Please provide the path to the external files directory using the EXTERNAL_FILES_DIR environment variable or by passing it as a command-line argument.")
+endif()
+
+file(GLOB_RECURSE PUGIXML_CPP "${EXTERNAL_FILES_DIR}/*/pugixml.cpp")
+if (NOT PUGIXML_CPP)
+    message(FATAL_ERROR "pugixml.cpp not found. Terminating.")
+    return()
+endif()
+
+file(GLOB_RECURSE RAPID_JSON_H "${EXTERNAL_FILES_DIR}/*/rapidjson.h")
+if (NOT RAPID_JSON_H)
+    message(FATAL_ERROR "rapidjson.h not found. Terminating.")
+    return()
+endif()
 
 include_directories(/opt/devtools/boost_1.83.0/include
         /opt/devtools/pugixml-1.14/src
@@ -17,18 +32,28 @@ include_directories(/opt/devtools/boost_1.83.0/include
 # Find ExampleLib
 find_package(Boost 1.83.0 COMPONENTS log)
 
-if(Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS})
-    add_executable(HackerChatClient
-            HackerChatClient_main.cpp
-            HackerChatClient.hpp
-            HackerChatClient.cpp
-            ${RAPID_JSON_H}
-            ${PUGIXML_CPP}
-            WebSocket/WebSocketClient.cpp
-            WebSocket/WebSocketClient.hpp)
-    target_link_libraries(HackerChatClient ${Boost_LIBRARIES})
+if(NOT Boost_FOUND)
+    message(FATAL_ERROR "Boost libraries not found. Terminating.")
 endif()
+
+# Define your CMake variables
+file(GLOB_RECURSE CONFIG_PATH "${CMAKE_HOME_DIRECTORY}/configs/HCClientConfig.json")
+if(NOT CONFIG_PATH)
+    message(FATAL_ERROR "WebSocket config file not found. Terminating.")
+    return()
+endif()
+
+include_directories(${Boost_INCLUDE_DIRS})
+add_executable(HackerChatClient
+        HackerChatClient_main.cpp
+        HackerChatClient.hpp
+        HackerChatClient.cpp
+        ${RAPID_JSON_H}
+        ${PUGIXML_CPP}
+        WebSocket/WebSocketClient.cpp
+        WebSocket/WebSocketClient.hpp)
+target_link_libraries(HackerChatClient ${Boost_LIBRARIES})
+
 
 
 

--- a/HackerChatClient/HackerChatClient.cpp
+++ b/HackerChatClient/HackerChatClient.cpp
@@ -63,7 +63,6 @@ int HackerChatClient::_Start() {
     try {
         //NOTE: Must configure IDE to store cmake build artifacts in build directory. This is temporary until
         //We configure the CMakeList.txt to do this automatically
-
         std::filesystem::path configPath = std::filesystem::current_path();
         configPath = configPath.parent_path();
         std::string configPathString = configPath.string();


### PR DESCRIPTION
When running cmake, the user must now define EXTERNAL_FILES_DIR, a cmake build variable that points to a single directory where all external libraries and include files.