### PR TITLE
Adds ability to set file paths for config files and dependencies

### DIFF
--- a/HackerChatClient/CMakeLists.txt
+++ b/HackerChatClient/CMakeLists.txt
@@ -9,7 +9,8 @@ set(Boost_USE_STATIC_RUNTIME OFF)
 
 # Check if the external files directory is provided
 if(NOT EXTERNAL_FILES_DIR)
-    message(FATAL_ERROR "Please provide the path to the external files directory using the EXTERNAL_FILES_DIR environment variable or by passing it as a command-line argument.")
+    message(FATAL_ERROR "Please provide the path to the external files directory using the
+    EXTERNAL_FILES_DIR environment variable or by passing it as a command-line argument.")
 endif()
 
 file(GLOB_RECURSE PUGIXML_CPP "${EXTERNAL_FILES_DIR}/*/pugixml.cpp")
@@ -33,13 +34,6 @@ find_package(Boost 1.83.0 COMPONENTS log)
 
 if(NOT Boost_FOUND)
     message(FATAL_ERROR "Boost libraries not found. Terminating.")
-endif()
-
-# Define your CMake variables
-file(GLOB_RECURSE CONFIG_PATH "${CMAKE_HOME_DIRECTORY}/configs/HCClientConfig.json")
-if(NOT CONFIG_PATH)
-    message(FATAL_ERROR "WebSocket config file not found. Terminating.")
-    return()
 endif()
 
 include_directories(${Boost_INCLUDE_DIRS})

--- a/HackerChatClient/HackerChatClient.cpp
+++ b/HackerChatClient/HackerChatClient.cpp
@@ -61,12 +61,14 @@ bool HackerChatClient::_Load(const std::string& configFilePath){
 
 int HackerChatClient::_Start() {
     try {
-        //NOTE: Must configure IDE to store cmake build artifacts in build directory. This is temporary until
-        //We configure the CMakeList.txt to do this automatically
-        std::filesystem::path configPath = std::filesystem::current_path();
-        configPath = configPath.parent_path();
-        std::string configPathString = configPath.string();
-        configPathString.append("/configs/HCClientConfig.json");
+        const char* configDir = std::getenv("HACKERCHAT_CLIENT_CONFIG_DIR");
+
+        if(configDir == nullptr){
+            BOOST_LOG_TRIVIAL(error) << "HACKERCHAT_CLIENT_CONFIG_DIR environment variable not defined. Terminating program.";
+        }
+
+        std::string configPathString(configDir);
+        configPathString.append("/HCClientConfig.json");
 
         if (_Load(configPathString)) {
             auto const text = "Hello!";

--- a/HackerChatClient/HackerChatClient_main.cpp
+++ b/HackerChatClient/HackerChatClient_main.cpp
@@ -1,8 +1,7 @@
 #include <iostream>
 #include "HackerChatClient.hpp"
 
-int main(){
-    //std::cout << "Hello world" << std::endl;
+int main(int argc, char* argv[]){
     HackerChatClient client;
     client._Start();
     return 0;


### PR DESCRIPTION
- Changes:

- > HACKERCHAT_CLIENT_CONFIG_DIR is an environment variable that must be defined to point to the directory where the HCClientConfig.json file is located